### PR TITLE
Joke NFT Bridge dApp - added us a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "community/bet-NBA"]
 	path = community/bet-NBA
 	url = https://github.com/0xVivaLabs/polymer-testnet1-nba
+[submodule "community/joke-Nft-Bridge"]
+	path = community/joke-Nft-Bridge
+	url = https://github.com/yurakas97/dapp.git

--- a/explore-apps.md
+++ b/explore-apps.md
@@ -21,3 +21,14 @@ Bet NBA:
 - Socials: @0xvivalabs
 - Attribution: [@script-money, @Glacier-Luo]
 ```
+
+Joke NFT Bridge:
+
+```markdown
+- Name: Joke NFT Bridge
+- GitHub url: https://github.com/yurakas97/dapp
+- Documentation: https://github.com/yurakas97/dapp/blob/main/README.md
+- Website: https://yurakas97.github.io/site/
+- Socials: @yura_kas (telegram)
+- Attribution: @yura_kas
+```


### PR DESCRIPTION
This project uses ERC20, and ERC721 token standards, oppenZeppelin lib. and custom solydity smart-contracts.

The key idea is to mint the original NFT based on randomly gotten jokes on the Optimism network, and write that joke as metadata of the NFT. Then user could bridge the NFT to the BASE network through IBC channel. The process of bridging means sending a packet with the user's wallet address, and joke as a string (from saved mapping in a smart contract by token ID) to the BASE and automatically minting(after the packet receiving) a new NFT with the same metadata, while the original one is burnt.

How to interact?
The site: https://yurakas97.github.io/site/
You can test it and enjoy it!!!

Check that IBC transfer and new NFT mint(on BASE) were successful you can by your address in BASE explorer)

The only thing to do. Due to my local server not having an HTTPS certificate yet, users need to allow their browser to send requests to "unsecured" sources to initialize the bridging process. They need to paste this in the browser chrome://flags/#unsafely-treat-insecure-origin-as-secure and add server address http://213.111.123.79:3000/ then turn it to "Enabled". That's it, now browser isn't going to block the user's requests to the server. And it should work as intended.