### PR TITLE
Raffle Proof System DApp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "community/IBC-Crosschain-Token"]
 	path = community/IBC-Crosschain-Token
 	url = https://github.com/GentlemenValidators/erc20-polymerlabs
+[submodule "community/Raffle-Proof-System"]
+	path = community/Raffle-Proof-System
+	url = https://github.com/yavuzkocca/Raffle-Proof-System

--- a/explore-apps.md
+++ b/explore-apps.md
@@ -71,3 +71,13 @@ Website: N/A
 Socials: @n_gentlemenvalidators
 Attribution: [@GentlemenValidators,@Pozzitron1337]
 ```
+
+Raffle Proof System
+```markdown
+Name: Raffle Proof System
+GitHub url: https://github.com/yavuzkocca/Raffle-Proof-System
+Documentation: https://github.com/yavuzkocca/Raffle-Proof-System/blob/main/README.md
+Website: N/A
+Socials: @yvzkc , @sturec
+Attribution: [@yavuzkocca,@sturec5]
+```


### PR DESCRIPTION
This application enables a user to enter a Raffle on a contract on OP Sepolia. After the raffle is completed, the winner gets a ERC-721 NFT for free on Base Sepolia even though the users entered via OP Sepolia.

Uses Polymer x IBC as the cross-chain format

Commits to the spirit of application specific chains/rollups where entering the raffle function can be specialized on one chain, NFT distribution to the winner of the raffle on another and both can form composable applications through interoperability.