### PR TITLE
Added [btn-gifting-with-polymer] dApp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "community/IBC-Crosschain-Token"]
 	path = community/IBC-Crosschain-Token
 	url = https://github.com/GentlemenValidators/erc20-polymerlabs
+[submodule "community/btn-gifting-with-polymer"]
+	path = community/btn-gifting-with-polymer
+	url = https://github.com/btuyen2606/btn-gifting-with-polymer

--- a/explore-apps.md
+++ b/explore-apps.md
@@ -71,3 +71,13 @@ Website: N/A
 Socials: @n_gentlemenvalidators
 Attribution: [@GentlemenValidators,@Pozzitron1337]
 ```
+
+BTN Gifting with Polymer:
+```markdown
+- Name: BTN Gifting with Polymer
+- GitHub url: https://github.com/btuyen2606/btn-gifting-with-polymer
+- Documentation: https://github.com/btuyen2606/btn-gifting-with-polymer/blob/main/README.md
+- Website: localhost
+- Socials: @btuyen
+- Attribution: [@btuyen2606, @khanhchuads, @conghc94]
+```


### PR DESCRIPTION
I just completed a dApp with an issue to give gifts to friends on the new chain with the following functionality:
- The user creates a gift, enters the wallet address, and sends a certain fee on the Base chain
- When creating a gift, the contract will use Universal Channel to send packets and create referal links on OP
- The recipient only needs to claim on OP to receive a fee to experience on Base.

Please review it for me