### PR TITLE
Raffle Proof System Updated Version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "community/polymer-lottery-contract"]
 	path = community/polymer-lottery-contract
 	url = https://github.com/tuananhht94/polymer-lottery-contract.git
+[submodule "community/Raffle-Proof-System"]
+	path = community/Raffle-Proof-System
+	url = https://github.com/yavuzkocca/Raffle-Proof-System.git

--- a/explore-apps.md
+++ b/explore-apps.md
@@ -82,3 +82,13 @@ Website: https://lottery.tuananh.xyz/
 Socials: @tuananhht94
 Attribution: [@tuananhht94,@juusokaj]
 ```
+
+Raffle Proof System
+```markdown
+Name: Raffle Proof System
+GitHub url: https://github.com/yavuzkocca/Raffle-Proof-System
+Documentation: https://github.com/yavuzkocca/Raffle-Proof-System/blob/main/README.md
+Website: N/A
+Socials: @yvzkc , @sturec
+Attribution: [@yavuzkocca,@sturec5]
+```


### PR DESCRIPTION
We have updated the project based on your latest instructions which were sending packet from frontend instead of backend. Also we hardcoded the NFT URL since we wanted the raffle attendants to receive the same NFT for now. Due to having a problem via updating the old repository, we deleted the old one and redeployed the project. We would appreciate you checking the new one. 